### PR TITLE
fix constraints, as they can't have extras

### DIFF
--- a/pip_pin/egg_info.py
+++ b/pip_pin/egg_info.py
@@ -1,5 +1,7 @@
 def tests_require(cmd, basename, filename):
-    cmd.write_file("tests_require", filename, "\n".join(cmd.distribution.tests_require or []))
+    cmd.write_file(
+        "tests_require", filename, "\n".join(cmd.distribution.tests_require or [])
+    )
 
 
 def develop_requires(cmd, basename, filename):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as f:
 # fmt: off
 setup(
     name='pip-pin',
-    version='0.0.6.post3',
+    version='0.0.7',
     packages=find_packages(),
     url='https://github.com/mrzechonek/python-pip-pin',
     license='MIT',


### PR DESCRIPTION
DEPRECATION: Constraints are only allowed to take the form of a package
name and a version specifier. Other forms were originally permitted as
an accident of the implementation, but were undocumented. The new
implementation of the resolver no longer supports these forms. A
possible replacement is replacing the constraint with a requirement.
Discussion can be found at https://github.com/pypa/pip/issues/8210

ERROR: Constraints cannot have extras