### PR TITLE
Support pinning dependencies defined in pyproject.toml

### DIFF
--- a/pip_pin/commands.py
+++ b/pip_pin/commands.py
@@ -5,7 +5,9 @@ from contextlib import suppress
 from copy import copy
 from enum import Enum
 
-from pkg_resources import DistributionNotFound, Requirement, get_distribution
+from pkg_resources import Requirement, get_distribution
+
+from pip_pin.util import get_develop_requires, get_tests_require
 
 PIP_PIN_DIR = "./.pip-pin"
 
@@ -53,8 +55,8 @@ class Command(distutils.cmd.Command):
 
         return {
             Env.INSTALL: parse(self.distribution.install_requires),
-            Env.TESTS: parse(self.distribution.tests_require),
-            Env.DEVELOP: parse(self.distribution.develop_requires),
+            Env.TESTS: parse(get_tests_require(self.distribution)),
+            Env.DEVELOP: parse(get_develop_requires(self.distribution)),
         }
 
 

--- a/pip_pin/egg_info.py
+++ b/pip_pin/egg_info.py
@@ -1,13 +1,15 @@
+from pip_pin import util
+
+
 def tests_require(cmd, basename, filename):
     cmd.write_file(
-        "tests_require", filename, "\n".join(cmd.distribution.tests_require or [])
+        "tests_require", filename, "\n".join(util.get_tests_require(cmd.distribution))
     )
 
 
 def develop_requires(cmd, basename, filename):
-    try:
-        reqs = cmd.distribution.develop_requires or []
-    except AttributeError:
-        reqs = []
-
-    cmd.write_file("develop_requires", filename, "\n".join(reqs))
+    cmd.write_file(
+        "develop_requires",
+        filename,
+        "\n".join(util.get_develop_requires(cmd.distribution)),
+    )

--- a/pip_pin/util.py
+++ b/pip_pin/util.py
@@ -1,0 +1,6 @@
+def get_develop_requires(dist):
+    return dist.develop_requires or dist.extras_require.get("develop", [])
+
+
+def get_tests_require(dist):
+    return dist.tests_require or dist.extras_require.get("tests", [])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as f:
 # fmt: off
 setup(
     name='pip-pin',
-    version='0.0.10',
+    version='0.0.11',
     packages=find_packages(),
     url='https://github.com/mrzechonek/python-pip-pin',
     license='MIT',


### PR DESCRIPTION
Project dependencies in pyproject.toml config file can only be defined in [project.dependencies] and [project.optional-dependencies] tables. Since setuptools 61.0.0 they are mapped to attributes in the Distribution object (see
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).

This commit enables pinning dependencies in projects which use only pyproject.toml and a stub setup.py file.

For an overview of gradual setup.py deprecation see https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html.